### PR TITLE
Updated README.md and added mocha to run the existing test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ As soon as you keep a reference to an object, array, arrow function, ... you do 
 
 ```js
 import myLib from 'my-lib'
-import { iterate } from 'leakage'
+import { iteration } from 'leakage'
 
 describe('myLib', () => {
   it('does not leak when doing stuff 1k times', () => {
-    iterate(1000, () => {
+    iteration(1000, () => {
       const instance = myLib.createInstance()
       instance.doStuff('foo', 'bar')
     })
@@ -34,7 +34,7 @@ describe('myLib', () => {
 })
 ```
 
-`iterate()` will run the arrow function 1000 times and throw an error if a memory leak has been detected.
+`iteration()` will run the arrow function 1000 times and throw an error if a memory leak has been detected.
 
 **Make sure you run all tests serially** in order to get clean heap diffs. Mocha should run them sequentially by default. Use `--runInBand` for Jest.
 
@@ -44,17 +44,17 @@ describe('myLib', () => {
 ```js
 import test from 'ava'
 import myLib from 'my-lib'
-import { iterate } from 'leakage'
+import { iteration } from 'leakage'
 
 test('myLib does not leak when doing stuff 1k times', () => {
-  iterate(1000, () => {
+  iteration(1000, () => {
     const instance = myLib.createInstance()
     instance.doStuff('foo', 'bar')
   })
 })
 ```
 
-`iterate()` will run the arrow function 1000 times and throw an error if a memory leak has been detected.
+`iteration()` will run the arrow function 1000 times and throw an error if a memory leak has been detected.
 
 **Make sure you run all tests serially** in order to get clean heap diffs. Tape should run them sequentially by default. Use `--serial` for AVA.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Memory leak testing for node. Write tests using your favorite test runner.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "standard lib/**/*.js"
+    "test": "node_modules/.bin/standard lib/**/*.js && node_modules/.bin/mocha test"
   },
   "author": "Andy Wermke <andy@dev.next-step-software.com>",
   "license": "MIT",
@@ -15,6 +15,7 @@
     "pretty-bytes": "^4.0.2"
   },
   "devDependencies": {
+    "mocha": "^3.2.0",
     "standard": "^8.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Memory leak testing for node. Write tests using your favorite test runner.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "node_modules/.bin/standard lib/**/*.js && node_modules/.bin/mocha test"
+    "test": "standard lib/**/*.js && mocha test"
   },
   "author": "Andy Wermke <andy@dev.next-step-software.com>",
   "license": "MIT",


### PR DESCRIPTION
When I imported 'iterate' from the package, the value was undefined. I realized that the README.md was misleading, so this PR adjusts it to reflect what the package exports ('iteration').

I'm having another issue with the library, which might end up in another PR, so I wanted to run the test suite to see what happens and realized that it didn't come with mocha and needed an improved test command (both using mocha and not relying on any local PATH modifications).