### PR TITLE
Use package.json files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "author": "Andy Wermke <andy@dev.next-step-software.com>",
   "license": "MIT",
+  "files": [
+    "lib/"
+  ],
   "dependencies": {
     "left-pad": "^1.1.3",
     "memwatch-next": "^0.3.0",


### PR DESCRIPTION
Thanks for building this! :tada: I've been putting off adding a memory leak test for one of my modules for a while, and this made it super easy.

This PR adds the `package.json` [`files` array](https://docs.npmjs.com/files/package.json#files) so that only required files are shipped as part of the module, which shrinks the bundle by 96%. Most of the reduction comes from not including `docs/failing-test.png`.

Before:

```sh
$ npm pack
leakage-0.1.0.tgz
$ wc -c < leakage-0.1.0.tgz
125500
$ tar -tf leakage-0.1.0.tgz
package/package.json
package/.npmignore
package/README.md
package/LICENSE
package/CHANGELOG.md
package/docs/failing-test.png
package/lib/heapDiffUtil.js
package/lib/index.js
package/lib/iteration.js
package/lib/leakErrorFactory.js
package/lib/saveHeapDiffs.js
package/test/sample.test.js
package/test/sampleLib.js
```

After:

```
$ npm pack
leakage.0.1.0.tgz
$ wc -c < leakage-0.1.0.tgz
4528
$ tar -tf leakage-0.1.0.tgz
package/package.json
package/README.md
package/LICENSE
package/CHANGELOG.md
package/lib/heapDiffUtil.js
package/lib/index.js
package/lib/iteration.js
package/lib/leakErrorFactory.js
package/lib/saveHeapDiffs.js
```