### PR TITLE
Rename `iteration()` => `iterate()`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
-const iteration = require('./iteration')
+const iterate = require('./iterate')
 
 module.exports = {
-  iteration
+  iterate,
+  iteration: iterate      // @deprecated Just here because v0.1.0 exported it as `iteration`.
 }

--- a/lib/iterate.js
+++ b/lib/iterate.js
@@ -3,13 +3,13 @@ const { getSubsequentHeapGrowths } = require('./heapDiffUtil')
 const createLeakErrorFactory = require('./leakErrorFactory')
 const saveHeapDiffs = require('./saveHeapDiffs')
 
-module.exports = iteration
+module.exports = iterate
 
 /**
  * @param {number} iterationCount
  * @param {Function} iteratorFunc
  */
-function iteration (iterationCount, iteratorFunc) {
+function iterate (iterationCount, iteratorFunc) {
   const garbageCollections = 6
   const throwOnSubsequentHeapGrows = 4
   iterationCount = iterationCount > garbageCollections ? iterationCount : garbageCollections

--- a/test/sample.test.js
+++ b/test/sample.test.js
@@ -1,11 +1,11 @@
 // Run with Mocha (Jest should work just fine, too)
 
 const sampleLib = require('./sampleLib')
-const { iteration } = require('../lib')
+const iterate = require('../lib').iterate
 
 describe('sampleLib', () => {
   it('does not leak when creating instances and doing stuff', () => {
-    iteration(100, () => {
+    iterate(100, () => {
       const instance = sampleLib.createInstance()   // <- memory leak in here
       instance.doStuff()
     })


### PR DESCRIPTION
Replacing the #1 PR.

- Renaming `iteration()` to `iterate()` instead of changing the docs
- Keeping the `iteration()` export, but with a `@deprecated`

@kroogs @btmills