### PR TITLE
Destruct iteration block

### DIFF
--- a/lib/iterate.js
+++ b/lib/iterate.js
@@ -22,8 +22,7 @@ function iterate (iterationCount, iteratorFunc) {
   memwatch.gc()
 
   iterationBlocks.forEach((block) => {
-    const from = block.from
-    const to = block.to
+    const { from, to } = block
 
     const heapDiff = new memwatch.HeapDiff()
     for (let iterationNo = from; iterationNo <= to; iterationNo++) {


### PR DESCRIPTION
Oops. Closing as the destructuring's not working with node v4.