### PR TITLE
Add prepublish script to build files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "babel src/ -d lib/",
+    "prepublish": "npm run build",
     "test": "npm run build && standard lib/**/*.js && mocha test/"
   },
   "author": "Andy Wermke <andy@dev.next-step-software.com>",


### PR DESCRIPTION
After #12 introduced a build step, it became possible that publishing from a clean repository without first running tests or explicitly building could result in an empty package on npm. This commit adds a `prepublish` script to build files before publishing.