### PR TITLE
Remove left pad

### DIFF
--- a/lib/testConstantHeapSize.js
+++ b/lib/testConstantHeapSize.js
@@ -1,5 +1,4 @@
 const ExtendableError = require('es6-error')
-const leftPad = require('left-pad')
 const prettyBytes = require('pretty-bytes')
 
 class MemoryLeakError extends ExtendableError { }
@@ -66,7 +65,7 @@ function prettyHeapContents (lastHeapDiff) {
   const byGrowth = (a, b) => (a.size_bytes < b.size_bytes ? 1 : -1)
 
   const formatHeapContent = (item) => (
-    `[${leftPad(prettyBytes(item.size_bytes), 10)}] [+ ${leftPad(item['+'], 3)}x] [- ${leftPad(item['-'], 3)}x] ${item.what}`
+    `[${prettyBytes(item.size_bytes).padStart(10)}] [+ ${String(item['+']).padStart(3)}x] [- ${String(item['-']).padStart(3)}x] ${item.what}`
   )
 
   const sortedDetails = [].concat(lastHeapDiff.change.details).sort(byGrowth)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,11 +1230,6 @@
         "array-includes": "^3.0.3"
       }
     },
-    "left-pad": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
-      "integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo="
-    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,11 @@
     "lib/"
   ],
   "engines": {
-    "node": ">= 6.0"
+    "node": ">= 8.0"
   },
   "dependencies": {
     "@aidemaster/node-memwatch": "^1.0.5",
     "es6-error": "^4.0.2",
-    "left-pad": "^1.1.3",
     "minimist": "^1.2.0",
     "pretty-bytes": "^4.0.2"
   },


### PR DESCRIPTION
Hi there @andywer, this is a small PR that removes the references to the deprecated `left-pad` library, I hope this is helpful!

The tests still pass, and the `package-lock` file has been updated accordingly.